### PR TITLE
Add cron GitHub action

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,13 @@
+name: Cron job
+
+on:
+  schedule:
+    - cron: '* * * * *'
+  workflow_dispatch:
+
+jobs:
+  run-cron:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Cron job running every minute"


### PR DESCRIPTION
## Summary
- run GitHub Actions workflow on a minutely cron schedule

## Testing
- `cmake -S . -B build` (fails: Failed to find nvcc)`

------
https://chatgpt.com/codex/tasks/task_e_6899a54c6abc83288e7b222ba0929fce